### PR TITLE
Remove version ranges on artifact dependencies

### DIFF
--- a/heroku-deploy/pom.xml
+++ b/heroku-deploy/pom.xml
@@ -18,17 +18,17 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>[2.3.0,)</version>
+      <version>2.3.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>[2.3.0,)</version>
+      <version>2.3.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
-      <version>[1.5,)</version>
+      <version>1.5</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>


### PR DESCRIPTION
Version ranges lead to unreproducible builds, pointless network traffic while Maven/Ivy check for available versions, and even unwanted cache-busting in Travis-CI's new [cached-dependencies](http://docs.travis-ci.com/user/caching/#Arbitrary-directories) feature.

cc @jkutner 
