### PR TITLE
Add `includeTarget` property

### DIFF
--- a/maven-plugin/.classpath
+++ b/maven-plugin/.classpath
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/maven-plugin/.project
+++ b/maven-plugin/.project
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>heroku-maven-plugin</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+</projectDescription>

--- a/maven-plugin/.settings/org.eclipse.core.resources.prefs
+++ b/maven-plugin/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,4 @@
+eclipse.preferences.version=1
+encoding//src/main/java=UTF-8
+encoding//src/main/resources=UTF-8
+encoding/<project>=UTF-8

--- a/maven-plugin/.settings/org.eclipse.jdt.core.prefs
+++ b/maven-plugin/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,5 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
+org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.source=1.7

--- a/maven-plugin/.settings/org.eclipse.m2e.core.prefs
+++ b/maven-plugin/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/maven-plugin/src/main/java/com/heroku/sdk/maven/CreateSlugMojo.java
+++ b/maven-plugin/src/main/java/com/heroku/sdk/maven/CreateSlugMojo.java
@@ -22,7 +22,9 @@ public class CreateSlugMojo extends HerokuMojo {
     CopyDependencies.execute(this.mavenProject, this.mavenSession, this.pluginManager);
 
     List<File> includedDirs = getIncludes();
-    includedDirs.add(getTargetDir());
+    if(isIncludeTarget()) {
+      includedDirs.add(getTargetDir());
+    }
 
     try {
       (new MavenApp(appName, getTargetDir().getParentFile(), getTargetDir(), getLog()))

--- a/maven-plugin/src/main/java/com/heroku/sdk/maven/DeployMojo.java
+++ b/maven-plugin/src/main/java/com/heroku/sdk/maven/DeployMojo.java
@@ -30,7 +30,9 @@ public class DeployMojo extends HerokuMojo {
     CopyDependencies.execute(this.mavenProject, this.mavenSession, this.pluginManager);
 
     List<File> includedDirs = getIncludes();
-    includedDirs.add(getTargetDir());
+    if(isIncludeTarget()) {
+      includedDirs.add(getTargetDir());
+    }
 
     try {
       (new MavenApp(appName, getTargetDir().getParentFile(), getTargetDir(), getLog())).deploy(

--- a/maven-plugin/src/main/java/com/heroku/sdk/maven/DeploySlugMojo.java
+++ b/maven-plugin/src/main/java/com/heroku/sdk/maven/DeploySlugMojo.java
@@ -32,7 +32,9 @@ public class DeploySlugMojo extends HerokuMojo {
     CopyDependencies.execute(this.mavenProject, this.mavenSession, this.pluginManager);
 
     List<File> includedDirs = getIncludes();
-    includedDirs.add(getTargetDir());
+    if(isIncludeTarget()) {
+      includedDirs.add(getTargetDir());
+    }
 
     try {
       (new MavenApp(appName, getTargetDir().getParentFile(), getTargetDir(), getLog()))

--- a/maven-plugin/src/main/java/com/heroku/sdk/maven/HerokuMojo.java
+++ b/maven-plugin/src/main/java/com/heroku/sdk/maven/HerokuMojo.java
@@ -95,6 +95,12 @@ public abstract class HerokuMojo extends AbstractMojo {
   protected String[] mIncludes = new String[0];
 
   /**
+   * If the target directory should also be included. Defaults to true.
+   * @parameter
+   */
+  protected boolean includeTarget = true;
+
+  /**
    * A filename where the slug is stored at, inside the heroku-target directory
    *
    * @parameter property="heroku.slugFilename"
@@ -121,6 +127,14 @@ public abstract class HerokuMojo extends AbstractMojo {
 
   public void setIncludes(String[] includes) {
     mIncludes = includes;
+  }
+
+  public boolean isIncludeTarget() {
+	return includeTarget;
+  }
+
+  public void setIncludeTarget(boolean includeTarget) {
+	this.includeTarget = includeTarget;
   }
 
   public String getSlugFilename() {


### PR DESCRIPTION
Add support for includeTarget property which  toggles if the full
`/target` directory is included or just the specified includes.

Allows an executable jar to be uploaded by using the following
configuration:

	<includeTarget>false</includeTarget>
	<includes>
		<include>${project.build.directory}/
			${project.artifactId}-${project.version}.jar</include>
	</includes>

Fixes: gh-10