### PR TITLE
configVars should overwrite existing values

### DIFF
--- a/heroku-deploy/src/main/java/com/heroku/sdk/deploy/ConfigVars.java
+++ b/heroku-deploy/src/main/java/com/heroku/sdk/deploy/ConfigVars.java
@@ -72,7 +72,7 @@ public class ConfigVars {
   }
 
   private Map<String, String> addConfigVar(String key, String value, Map<String, String> existingConfigVars) {
-    return addConfigVar(key, value, existingConfigVars, false);
+    return addConfigVar(key, value, existingConfigVars, true);
   }
 
   private Map<String, String> addConfigVar(String key, String value, Map<String, String> existingConfigVars, Boolean force) {


### PR DESCRIPTION
This matches the documentation and is what we want; configuration by code.

When we want to change a config var, we want to do it in the code, not change it in the code and then have to remember to heroku config:set it afterward. Similarly, having made some experimental changes, we want to be able to nuke them easily. The correct way to make the change permanent, after all, is to change the code!
Cheers.