### PR TITLE
Added mechanism to set api key programmatically

### DIFF
--- a/heroku-deploy/src/main/java/com/heroku/sdk/deploy/DeployWar.java
+++ b/heroku-deploy/src/main/java/com/heroku/sdk/deploy/DeployWar.java
@@ -21,6 +21,11 @@ public class DeployWar extends WarApp {
     FileUtils.copyURLToFile(webappRunnerUrl, webappRunnerJar);
   }
 
+  public DeployWar(String name, File warFile, URL webappRunnerUrl, String apiKey) throws IOException {
+      this(name, warFile, webappRunnerUrl);
+      this.deployer.setEncodedApiKey(apiKey);
+  }
+  
   @Override
   protected Map<String,String> defaultProcTypes() {
     Map<String,String> processTypes = new HashMap<String, String>();

--- a/heroku-deploy/src/main/java/com/heroku/sdk/deploy/Deployer.java
+++ b/heroku-deploy/src/main/java/com/heroku/sdk/deploy/Deployer.java
@@ -207,7 +207,7 @@ public abstract class Deployer {
       if (apiKey == null || apiKey.isEmpty()) {
         throw new RuntimeException("Could not get API key! Please install the toolbelt and login with `heroku login` or set the HEROKU_API_KEY environment variable.");
       }
-      encodedApiKey = new BASE64Encoder().encode((":" + apiKey).getBytes());
+      setEncodedApiKey(apiKey);
     }
     return encodedApiKey;
   }
@@ -291,5 +291,9 @@ public abstract class Deployer {
 
     ObjectId head = repository.resolve("HEAD");
     return head == null ? null : head.name();
+  }
+  
+  public void setEncodedApiKey(String apiKey) {
+      encodedApiKey = new BASE64Encoder().encode((":" + apiKey).getBytes());
   }
 }


### PR DESCRIPTION
This PR allows specifying an apikey to DeployWar class (see #24), which injects the key to Deployer class.

The current way of specifying the key (using HEROKU_API_KEY env var) limits the deploying to one account. These changes remove this limit for any code using heroku-deploy project.