### PR TITLE
fix temp directory not deleted

### DIFF
--- a/heroku-deploy/src/main/java/com/heroku/sdk/deploy/App.java
+++ b/heroku-deploy/src/main/java/com/heroku/sdk/deploy/App.java
@@ -3,6 +3,7 @@ package com.heroku.sdk.deploy;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -66,7 +67,14 @@ public class App implements Logger  {
   }
 
   protected static File createTempDir() throws IOException {
-    return Files.createTempDirectory("heroku-deploy").toFile();
+    File f = Files.createTempDirectory("heroku-deploy").toFile();
+    deleteTemporaryDirectoryOnShutdownHook(f.toPath());
+    return f;
+  }
+
+  private static void deleteTemporaryDirectoryOnShutdownHook(final Path path) {
+    final Runnable runnable = new DeleteDirectoryRunnable(path);
+    Runtime.getRuntime().addShutdownHook(new Thread(runnable));
   }
 
   protected String relativize(File path) {

--- a/heroku-deploy/src/main/java/com/heroku/sdk/deploy/DeleteDirectoryRunnable.java
+++ b/heroku-deploy/src/main/java/com/heroku/sdk/deploy/DeleteDirectoryRunnable.java
@@ -1,0 +1,49 @@
+// $Id\$
+package com.heroku.sdk.deploy;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+// from https://stackoverflow.com/questions/15022219/does-files-createtempdirectory-remove-the-directory-after-jvm-exits-normally
+public class DeleteDirectoryRunnable implements Runnable {
+
+    private final Path path;
+
+    private static final SimpleFileVisitor<Path> visitor = new SimpleFileVisitor<Path>() {
+        @Override
+        public FileVisitResult visitFile(Path file,
+                                         @SuppressWarnings("unused") BasicFileAttributes attrs)
+                throws IOException {
+            Files.delete(file);
+            return FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult postVisitDirectory(Path dir, IOException e)
+                throws IOException {
+            if (e == null) {
+                Files.delete(dir);
+                return FileVisitResult.CONTINUE;
+            }
+            // directory iteration failed
+            throw e;
+        }
+    };
+
+    public DeleteDirectoryRunnable(Path path) {
+        this.path = path;
+    }
+
+    @Override
+    public void run() {
+        try {
+            Files.walkFileTree(path, visitor);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to delete " + path, e);
+        }
+    }
+}

--- a/heroku-deploy/src/main/java/com/heroku/sdk/deploy/Deployer.java
+++ b/heroku-deploy/src/main/java/com/heroku/sdk/deploy/Deployer.java
@@ -381,4 +381,5 @@ public class Deployer {
   protected String toPropertiesString() {
     return "client=" + client + "\n";
   }
+
 }

--- a/heroku-deploy/src/test/java/com/heroku/sdk/deploy/DeleteDirectoryRunnableTest.java
+++ b/heroku-deploy/src/test/java/com/heroku/sdk/deploy/DeleteDirectoryRunnableTest.java
@@ -1,0 +1,55 @@
+// $Id\$
+package com.heroku.sdk.deploy;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Christian Kaiser 08/30/19
+ */
+public class DeleteDirectoryRunnableTest {
+
+    @Test
+    public void testRecursiveDirectoryDeletion() throws Exception {
+        final File tempDir = Files.createTempDirectory("DeleteDirectoryRunnableTest_").toFile();
+        assertTrue(tempDir.exists());
+        assertTrue(tempDir.isDirectory());
+
+        createFiles(tempDir);
+
+        final DeleteDirectoryRunnable runnable = new DeleteDirectoryRunnable(tempDir.toPath());
+        Thread t = new Thread(runnable);
+
+        t.start();
+
+        t.join(3000);
+        assertFalse(tempDir.exists());
+    }
+
+    private void createFiles(File tempDir) throws IOException {
+        File f1 = new File(tempDir,"f1");
+        f1.createNewFile();
+
+        File f2 = new File(tempDir,"f2");
+        f2.createNewFile();
+
+        File d1 = new File(tempDir,"d1");
+        d1.mkdir();
+
+        File d11 = new File(d1,"d11");
+        d11.mkdir();
+
+        File f111 = new File(d11,"f111");
+        f111.mkdir();
+
+        File f11 = new File(d1,"f11");
+        f11.mkdir();
+    }
+
+}


### PR DESCRIPTION
This is related to https://github.com/heroku/heroku-cli-deploy/issues/18. If the command 

``heroku deploy:jar my-application.jar --app my-application``

is executed, the created temp directory is not deleted after the program ends.

I added a shutdown hook, so the directory is deleted after the java process ends. I did a unit test, but was not able to test end to end due to missing knowledge. Please take a look if it is usefull.

