### PR TITLE
Ensure compatibility with webapp-runner that uses "com.heroku" group id

### DIFF
--- a/heroku-deploy/src/main/java/com/heroku/sdk/deploy/DeployWar.java
+++ b/heroku-deploy/src/main/java/com/heroku/sdk/deploy/DeployWar.java
@@ -11,13 +11,12 @@ import java.util.Map;
 
 import com.heroku.sdk.deploy.utils.Main;
 import com.heroku.sdk.deploy.utils.Properties;
+import com.heroku.sdk.deploy.utils.WebappRunnerResolver;
 import org.apache.commons.io.FileUtils;
 
 public class DeployWar extends WarApp {
 
   public static final String DEFAULT_WEBAPP_RUNNER_VERSION = Properties.getProperty("webapp-runner.version");
-
-  private static final String WEBAPP_RUNNER_URL_FORMAT="http://central.maven.org/maven2/com/github/jsimone/webapp-runner/%s/webapp-runner-%s.jar";
 
   public DeployWar(String name, File warFile, URL webappRunnerUrl, List<String> buildpacks) throws IOException {
     super(name, buildpacks);
@@ -76,7 +75,7 @@ public class DeployWar extends WarApp {
     final String webappRunnerVersion = System.getProperty(
             "heroku.webappRunnerVersion", DEFAULT_WEBAPP_RUNNER_VERSION);
     final String webappRunnerUrl = System.getProperty(
-            "heroku.webappRunnerUrl", String.format(WEBAPP_RUNNER_URL_FORMAT, webappRunnerVersion, webappRunnerVersion));
+            "heroku.webappRunnerUrl", WebappRunnerResolver.getUrlForVersion(webappRunnerVersion));
 
     if (warFile == null) {
       throw new IllegalArgumentException("Path to WAR file must be provided with heroku.warFile system property!");

--- a/heroku-deploy/src/main/java/com/heroku/sdk/deploy/utils/WebappRunnerResolver.java
+++ b/heroku-deploy/src/main/java/com/heroku/sdk/deploy/utils/WebappRunnerResolver.java
@@ -1,0 +1,130 @@
+package com.heroku.sdk.deploy.utils;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Resolves group id and download URLs for webapp-runner. At one point its group id changed, creating the need
+ * to discern which version uses which group id and download URL.
+ */
+public class WebappRunnerResolver {
+
+    public static String getGroupIdForVersion(String version) {
+        return isLegacyVersion(version) ? "com.github.jsimone" : "com.heroku";
+    }
+
+    public static String getUrlForVersion(String version) {
+        String pattern = isLegacyVersion(version)
+                ? "http://central.maven.org/maven2/com/github/jsimone/webapp-runner/%s/webapp-runner-%s.jar"
+                : "http://central.maven.org/maven2/com/heroku/webapp-runner/%s/webapp-runner-%s.jar";
+
+        return String.format(pattern, version, version);
+    }
+
+    private static boolean isLegacyVersion(String version) {
+        return knownLegacyVersions.contains(version);
+    }
+
+    // Known versions that use the legacy group id "com.github.jsimone". Since there are only a handful of
+    // legacy versions around, maintaining a static list is more robust than using a more complex version matching
+    // mechanism.
+    private static final List<String> knownLegacyVersions = Arrays.asList(
+            "9.0.27.1",
+            "9.0.27.0",
+            "9.0.24.1",
+            "9.0.24.0",
+            "9.0.22.0",
+            "9.0.20.1",
+            "9.0.20.0",
+            "9.0.19.1",
+            "9.0.19.0",
+            "9.0.17.0",
+            "9.0.16.0",
+            "9.0.14.0",
+            "9.0.13.0",
+            "9.0.11.0",
+            "9.0.8.1",
+            "9.0.8.0",
+            "8.5.47.2",
+            "8.5.47.1",
+            "8.5.47.0",
+            "8.5.45.0",
+            "8.5.43.1",
+            "8.5.43.0",
+            "8.5.41.1",
+            "8.5.41.0",
+            "8.5.40.1",
+            "8.5.40.0",
+            "8.5.39.0",
+            "8.5.38.0",
+            "8.5.37.1",
+            "8.5.37.0",
+            "8.5.35.0",
+            "8.5.34.1",
+            "8.5.34.0",
+            "8.5.33.0",
+            "8.5.32.1",
+            "8.5.32.0",
+            "8.5.31.1",
+            "8.5.31.0",
+            "8.5.30.0",
+            "8.5.29.0",
+            "8.5.28.0",
+            "8.5.27.0",
+            "8.5.24.0",
+            "8.5.23.1",
+            "8.5.23.0",
+            "8.5.20.1",
+            "8.5.20.0",
+            "8.5.15.1",
+            "8.5.15.0",
+            "8.5.11.3",
+            "8.5.11.2",
+            "8.5.11.1",
+            "8.5.11.0",
+            "8.5.9.0",
+            "8.5.5.2",
+            "8.5.5.1",
+            "8.5.5.0",
+            "8.0.52.0",
+            "8.0.51.0",
+            "8.0.50.0",
+            "8.0.47.0",
+            "8.0.44.0",
+            "8.0.39.0",
+            "8.0.33.4",
+            "8.0.33.3",
+            "8.0.33.2",
+            "8.0.33.1",
+            "8.0.33.0",
+            "8.0.30.2",
+            "8.0.30.1",
+            "8.0.30.0",
+            "8.0.24.1",
+            "8.0.24.0",
+            "8.0.23.0",
+            "8.0.18.0-M1",
+            "7.0.91.0",
+            "7.0.88.0",
+            "7.0.86.0",
+            "7.0.85.0",
+            "7.0.84.0",
+            "7.0.82.0",
+            "7.0.57.2",
+            "7.0.57.1",
+            "7.0.40.2",
+            "7.0.40.1",
+            "7.0.40.0",
+            "7.0.34.3",
+            "7.0.34.2",
+            "7.0.34.1",
+            "7.0.34.0",
+            "7.0.30.1",
+            "7.0.29.3",
+            "7.0.27.1",
+            "7.0.22.3",
+            "7.0.22.2",
+            "7.0.22.1",
+            "7.0.22"
+    );
+}

--- a/maven-plugin/src/main/java/com/heroku/sdk/maven/executor/CopyWebappRunner.java
+++ b/maven-plugin/src/main/java/com/heroku/sdk/maven/executor/CopyWebappRunner.java
@@ -1,6 +1,7 @@
 package com.heroku.sdk.maven.executor;
 
 import com.heroku.sdk.deploy.DeployWar;
+import com.heroku.sdk.deploy.utils.WebappRunnerResolver;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.BuildPluginManager;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -20,7 +21,8 @@ public class CopyWebappRunner extends MojoExecutor {
     public static void execute(MavenProject mavenProject,
                                MavenSession mavenSession,
                                BuildPluginManager pluginManager,
-                               String webappRunnerversion) throws MojoExecutionException {
+                               String webappRunnerVersion) throws MojoExecutionException {
+
         executeMojo(
                 plugin(
                         groupId("org.apache.maven.plugins"),
@@ -31,9 +33,9 @@ public class CopyWebappRunner extends MojoExecutor {
                 configuration(
                         element(name("artifactItems"),
                                 element(name("artifactItem"),
-                                        element(name("groupId"), "com.github.jsimone"),
+                                        element(name("groupId"), WebappRunnerResolver.getGroupIdForVersion(webappRunnerVersion)),
                                         element(name("artifactId"), "webapp-runner"),
-                                        element(name("version"), webappRunnerversion),
+                                        element(name("version"), webappRunnerVersion),
                                         element(name("destFileName"), "webapp-runner.jar")))
                 ),
                 executionEnvironment(


### PR DESCRIPTION
We moved webapp-runner to a new group id. This requires a switch between the old and new group id depending on the used version in this plugin.