### PR TITLE
Add TLS bug workaround for 11.0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,4 @@ matrix:
   fast_finish: true
   include:
     - jdk: openjdk8
-    - before_install:
-        - wget https://github.com/malax/bach/raw/master/install-jdk.sh
-        # Manually install JDK 11 to get a newer version than travis' default to work around a JDK bug in 11.0.2:
-        # https://bugs.openjdk.java.net/browse/JDK-8220723
-        - source ./install-jdk.sh --feature 11 --url "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jdk_x64_linux_hotspot_11.0.6_10.tar.gz"
+    - jdk: openjdk11

--- a/heroku-deploy-standalone/pom.xml
+++ b/heroku-deploy-standalone/pom.xml
@@ -103,7 +103,7 @@
                   <goal>jar</goal>
                 </goals>
                 <configuration>
-                  <additionalparam>-Xdoclint:none</additionalparam>
+                  <doclint>none</doclint>
                   <sourcepath>
                     ${project.parent.basedir}/heroku-deploy/src/main/java
                   </sourcepath>

--- a/heroku-deploy/src/main/java/com/heroku/sdk/deploy/api/HerokuDeployApi.java
+++ b/heroku-deploy/src/main/java/com/heroku/sdk/deploy/api/HerokuDeployApi.java
@@ -3,6 +3,7 @@ package com.heroku.sdk.deploy.api;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.heroku.sdk.deploy.util.CustomHttpClientBuilder;
 import com.heroku.sdk.deploy.util.PropertiesUtils;
 import com.heroku.sdk.deploy.util.Util;
 import org.apache.http.HttpEntity;
@@ -13,15 +14,11 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
 import org.eclipse.jgit.util.Base64;
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -72,7 +69,7 @@ public class HerokuDeployApi {
         apiPayloadEntity.setContentEncoding("UTF-8");
 
         // Send request
-        CloseableHttpClient client = HttpClients.createSystem();
+        CloseableHttpClient client = CustomHttpClientBuilder.build();
 
         HttpPost request = new HttpPost("https://api.heroku.com/apps/" + appName + "/builds");
         httpHeaders.forEach(request::setHeader);
@@ -85,7 +82,7 @@ public class HerokuDeployApi {
 
     public BuildInfo getBuildInfo(String appName, String buildId) throws IOException, HerokuDeployApiException {
         ObjectMapper mapper = new ObjectMapper();
-        CloseableHttpClient client = HttpClients.createSystem();
+        CloseableHttpClient client = CustomHttpClientBuilder.build();
 
         HttpUriRequest request = new HttpGet("https://api.heroku.com/apps/" + appName + "/builds/" + buildId);
         httpHeaders.forEach(request::setHeader);
@@ -96,7 +93,7 @@ public class HerokuDeployApi {
     }
 
     public Stream<String> followBuildOutputStream(URI buildOutputStreamUri) throws IOException {
-        CloseableHttpClient client = HttpClients.createSystem();
+        CloseableHttpClient client = CustomHttpClientBuilder.build();
 
         HttpGet request = new HttpGet(buildOutputStreamUri);
         httpHeaders.forEach(request::setHeader);

--- a/heroku-deploy/src/main/java/com/heroku/sdk/deploy/lib/deploymemt/Deployer.java
+++ b/heroku-deploy/src/main/java/com/heroku/sdk/deploy/lib/deploymemt/Deployer.java
@@ -4,11 +4,11 @@ import com.heroku.api.HerokuAPI;
 import com.heroku.api.Source;
 import com.heroku.sdk.deploy.api.*;
 import com.heroku.sdk.deploy.lib.OutputAdapter;
+import com.heroku.sdk.deploy.util.CustomHttpClientBuilder;
 import com.heroku.sdk.deploy.util.io.UploadProgressHttpEntity;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.FileEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
 
 import javax.net.ssl.SSLHandshakeException;
 import java.io.IOException;
@@ -108,7 +108,7 @@ public final class Deployer {
     private static void uploadSourceBlob(Path path, URI destination, BiConsumer<Long, Long> progressConsumer) throws IOException {
         long fileSize = Files.size(path);
 
-        CloseableHttpClient client = HttpClients.createSystem();
+        CloseableHttpClient client = CustomHttpClientBuilder.build();
 
         HttpPut request = new HttpPut(destination);
         request.setEntity(new UploadProgressHttpEntity(new FileEntity(path.toFile()), bytes -> progressConsumer.accept(bytes, fileSize)));

--- a/heroku-deploy/src/main/java/com/heroku/sdk/deploy/util/CustomHttpClientBuilder.java
+++ b/heroku-deploy/src/main/java/com/heroku/sdk/deploy/util/CustomHttpClientBuilder.java
@@ -1,0 +1,53 @@
+package com.heroku.sdk.deploy.util;
+
+import org.apache.http.conn.socket.LayeredConnectionSocketFactory;
+import org.apache.http.conn.ssl.DefaultHostnameVerifier;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.conn.util.PublicSuffixMatcherLoader;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.TextUtils;
+
+import javax.net.ssl.SSLSocketFactory;
+
+public class CustomHttpClientBuilder {
+
+    public static CloseableHttpClient build() {
+        /*
+        Workaround for JDK-8220723 (https://bugs.openjdk.java.net/browse/JDK-8220723)
+        We limit the available protocols to TLS 1.2 to avoid triggering the bug with TLS 1.3.
+
+        Version 11.0.2 is significant to us as it is the default OpenJDK version on Travis CI for Java 11. Since running
+        on CI/CD is one of the main use-cases for this library, we can justify this workaround for a bug in an older
+        version of the JDK.
+
+        As soon as 11.0.2 is no longer the default on Travis please consider removing this workaround.
+
+        Issue: https://github.com/heroku/heroku-maven-plugin/issues/71
+        */
+        if (System.getProperty("java.version").equals("11.0.2")) {
+            final String[] supportedProtocols = new String[] { "TLSv1.2" };
+            final String[] supportedCipherSuites = split(System.getProperty("https.cipherSuites"));
+
+            LayeredConnectionSocketFactory sslConnectionSocketFactory = new SSLConnectionSocketFactory(
+                    (SSLSocketFactory) SSLSocketFactory.getDefault(),
+                    supportedProtocols, supportedCipherSuites, new DefaultHostnameVerifier(PublicSuffixMatcherLoader.getDefault()));
+
+            return HttpClientBuilder
+                    .create()
+                    .useSystemProperties()
+                    .setSSLSocketFactory(sslConnectionSocketFactory)
+                    .build();
+        }
+
+        return HttpClients.createSystem();
+    }
+
+    private static String[] split(final String s) {
+        if (TextUtils.isBlank(s)) {
+            return null;
+        }
+        return s.split(" *, *");
+    }
+}


### PR DESCRIPTION
Fixes #71 

Travis uses 11.0.2 as their default OpenJDK version for Java 11. `heroku-maven-plugin` is affected by a bug in that version, causing deploys to fail due to an issue in the TLS 1.3 implementation. This workaround disables TLS 1.3 for HTTPS requests made by this library when running on Java `11.0.2`.