### PR TITLE
Add buildVersion parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,20 @@ The plugin will detect the appName from the following places in this order:
 For example, if you specify the `heroku.appName` system property, the Maven configuration shown above will have
 no effect. This is useful for [deploying multiple apps](#deploying-to-multiple-apps).
 
+### buildVersion
+
+The build version of the application to deploy.
+
+```xml
+<buildVersion>v1.0.0</buildVersion>
+```
+
+The plugin will detect the buildVersion from the following places in this order:
+
+* The `heroku.buildVersion` system property
+* The Maven configuration (shown above)
+* The Maven project version (`${project.version}`)
+
 ### jdkVersion
 
 The JDK version to use for your application.

--- a/heroku-maven-plugin/src/main/java/com/heroku/sdk/maven/mojo/AbstractHerokuDeployMojo.java
+++ b/heroku-maven-plugin/src/main/java/com/heroku/sdk/maven/mojo/AbstractHerokuDeployMojo.java
@@ -86,7 +86,7 @@ public abstract class AbstractHerokuDeployMojo extends AbstractHerokuMojo {
                     .orElseThrow(() -> new MojoExecutionException("Could not determine app name, please configure it explicitly!"));
 
             DeploymentDescriptor deploymentDescriptor
-                    = new DeploymentDescriptor(appName, super.buildpacks, super.configVars, sourceBlob, mavenProject.getVersion());
+                    = new DeploymentDescriptor(appName, super.buildpacks, super.configVars, sourceBlob, super.buildVersion);
 
             String apiKey = ApiKeyResolver
                     .resolve(projectDirectory)

--- a/heroku-maven-plugin/src/main/java/com/heroku/sdk/maven/mojo/AbstractHerokuMojo.java
+++ b/heroku-maven-plugin/src/main/java/com/heroku/sdk/maven/mojo/AbstractHerokuMojo.java
@@ -35,6 +35,12 @@ public abstract class AbstractHerokuMojo extends AbstractMojo {
   protected String appName = null;
 
   /**
+   * The build version of the application to deploy.
+   */
+  @Parameter(name="buildVersion", property="heroku.buildVersion", defaultValue = "${project.version}")
+  protected String buildVersion = null;
+
+  /**
    * The version of the JDK Heroku with run the app with.
    */
   @Parameter(name="jdkVersion", property="heroku.jdkVersion")


### PR DESCRIPTION
Let deployer version be overridden using a system property or plugin configuration. Fallback to `${project.version}`.

The motivation is to use a plugin like [git-commit-id](https://github.com/git-commit-id/git-commit-id-maven-plugin) to manage the deployer version without changing the pom version.

Currently, the version is taken from `mavenProject.getVersion()` and can't be overridden.