### PR TITLE
Convert heroku/heroku-maven-plugin to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: heroku/heroku-maven-plugin/ci
+on:
+  push:
+env:
+  HEROKU_API_KEY: xxxxxxx
+  HEROKU_API_USER: xxxxxxx
+jobs:
+  maven:
+    runs-on: sfdc-hk-ubuntu-latest
+    strategy:
+      matrix:
+        executor:
+        - openjdk-8
+        - openjdk-11
+    steps:
+    - shell: bash
+      run: |-
+        if [[ $(command -v heroku) == "" ]]; then
+          curl https://cli-assets.heroku.com/install.sh | sh
+        else
+          echo "Heroku is already installed. No operation was performed."
+        fi
+    - uses: actions/checkout@v2
+    - run: "./mvnw clean install -Pit"
+    - name: Save test results
+      run: |-
+        mkdir -p ~/test-results/junit/
+        find . -type f -regex ".*/target/surefire-reports/.*xml" -exec cp {} ~/test-results/junit/ \;
+      if: always()
+    - uses: actions/upload-artifact@v2
+      with:
+        path: "~/test-results"
+    - uses: actions/upload-artifact@v2
+      with:
+        path: "~/test-results/junit"


### PR DESCRIPTION
Pipeline migrated from [Circle CI](https://app.circleci.com/pipelines/github/heroku/heroku-maven-plugin) :tada:

## Manual steps

Perform the follow steps to complete the migration:

### heroku/heroku-maven-plugin/ci
- [ ] Ensure a runner with the following labels exists: sfdc-hk-ubuntu-latest