### PR TITLE
Fix `heroku auth:token` error handling

### DIFF
--- a/heroku-deploy/src/main/java/com/heroku/sdk/deploy/util/HerokuCli.java
+++ b/heroku-deploy/src/main/java/com/heroku/sdk/deploy/util/HerokuCli.java
@@ -13,7 +13,13 @@ import java.util.stream.Collectors;
 public class HerokuCli {
 
     public static Optional<String> runAuthToken(Path workingDirectory) throws IOException {
-        return Optional.ofNullable(runRaw(workingDirectory,"auth:token").get(0));
+        List<String> lines = runRaw(workingDirectory,"auth:token");
+
+        if (lines.isEmpty()) {
+            return Optional.empty();
+        } else {
+            return Optional.of(lines.get(0));
+        }
     }
 
     private static List<String> runRaw(Path workingDirectory, String... command) throws IOException {


### PR DESCRIPTION
When `heroku auth:token` doesn't output a token to use, the plugin will crash when it tries to get the first line of the CLI output. This PR fixes the incorrect handling for that case. The previous code expected `null` to be returned by `.get(0)` when the zeroth item does not exist. `List#get(int)` actually throws an exception when the index is out of bounds.

This is most likely the root cause for #88.