### PR TITLE
Finish renaming to Heroku JVM Application Deployer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: rustup update
       - name: Install Heroku CLI
         run: curl https://cli-assets.heroku.com/install.sh | sh
-      - name: Package heroku-deploy-standalone
+      - name: Package heroku-jvm-application-deployer
         run: "./mvnw --batch-mode package"
       - name: Package integration test fixtures
         working-directory: "integration-test/fixtures/war-app"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## main
 
-### heroku-deploy-standalone
+### heroku-jvm-application-deployer
 
 * Add proper CLI to configure all aspects of app deployment. Previously used Java properties are no longer supported. See `--help` for usage. ([#232](https://github.com/heroku/heroku-maven-plugin/pull/232))
-* Unify usage between WAR and JAR files. heroku-deploy-standalone will now automatically use the correct mode based on file extension. ([#232](https://github.com/heroku/heroku-maven-plugin/pull/232))
+* Unify usage between WAR and JAR files. heroku-jvm-application-deployer will now automatically use the correct mode based on file extension. ([#232](https://github.com/heroku/heroku-maven-plugin/pull/232))
 * Default `webapp-runner` version is now always the most recently released version. ([#232](https://github.com/heroku/heroku-maven-plugin/pull/232))
 
 ## 3.0.5

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Heroku JVM Application Deployer &emsp; ![License](https://img.shields.io/github/license/heroku/heroku-maven-plugin) ![Maven Central](https://img.shields.io/maven-central/v/com.heroku.sdk/heroku-sdk-parent) [![CI](https://github.com/heroku/heroku-maven-plugin/actions/workflows/ci.yml/badge.svg)](https://github.com/heroku/heroku-maven-plugin/actions/workflows/ci.yml)
+# Heroku JVM Application Deployer &emsp; ![License](https://img.shields.io/github/license/heroku/heroku-maven-plugin) ![Maven Central](https://img.shields.io/maven-central/v/com.heroku/heroku-jvm-application-deployer) [![CI](https://github.com/heroku/heroku-maven-plugin/actions/workflows/ci.yml/badge.svg)](https://github.com/heroku/heroku-maven-plugin/actions/workflows/ci.yml)
 
 Command line tool to deploy JVM applications directly to Heroku without pushing to a Git repository. It uses 
 [Heroku's Platform API](https://devcenter.heroku.com/articles/platform-api-quickstart). This can be useful when deploying from a CI server, deploying pre-built JAR or WAR files.
@@ -22,21 +22,22 @@ It will automatically include and configure a Tomcat server via [webapp-runner](
 
 ## Installation
 
-Download the latest release from [Maven Central](https://repo1.maven.org/maven2/com/heroku/sdk/heroku-deploy-standalone/).
+Download the latest release from [Maven Central](https://repo1.maven.org/maven2/com/heroku/heroku-jvm-application-deployer/).
 The JAR file contains all required dependencies.
 
 ## Usage
 
 ```shell
-java -jar heroku-deploy-standalone-0.0.0.jar --help
+java -jar heroku-jvm-application-deployer.jar --help
 ```
 
 ```
-Usage: heroku-deploy-standalone [-hV] [--disable-auto-includes] [-a=<appName>]
-                                [-j=<jdkString>] [--jar-opts=<jarFileOpts>]
-                                [--webapp-runner-version=<webappRunnerVersion>]
-                                [-b[=<buildpacks>...]]... [-i
-                                [=<includedPaths>...]]... <mainFile>
+Usage: heroku-jvm-application-deployer [-hV] [--disable-auto-includes]
+                                       [-a=<appName>] [-j=<jdkString>]
+                                       [--jar-opts=<jarFileOpts>]
+                                       [--webapp-runner-version=<webappRunnerVer
+                                       sion>] [-b[=<buildpacks>...]]... [-i
+                                       [=<includedPaths>...]]... <mainFile>
 Application for deploying Java applications to Heroku.
       <mainFile>          The JAR or WAR file to deploy.
   -a, --app=<appName>     The name of the Heroku app to deploy to.
@@ -53,7 +54,7 @@ Application for deploying Java applications to Heroku.
   -V, --version           Print version information and exit.
       --webapp-runner-version=<webappRunnerVersion>
                           The version of webapp-runner to use. Defaults to the
-                            most recent version (9.0.80.0).
+                            most recent version (9.0.83.0).
 ```
 
 

--- a/integration-test/src/lib.rs
+++ b/integration-test/src/lib.rs
@@ -47,7 +47,7 @@ impl Drop for TestContext {
 }
 
 #[must_use]
-pub fn heroku_deploy_standalone_path() -> PathBuf {
+pub fn heroku_jvm_application_deployer_jar_path() -> PathBuf {
     let maven_target_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("..")
         .join("target");

--- a/integration-test/tests/integration_tests.rs
+++ b/integration-test/tests/integration_tests.rs
@@ -8,7 +8,7 @@ fn basic_war_app() {
             Command::new("java")
                 .args([
                     "-jar",
-                    &heroku_deploy_standalone_path().to_string_lossy(),
+                    &heroku_jvm_application_deployer_jar_path().to_string_lossy(),
                     &context
                         .app_dir
                         .join("target/test-1.0-SNAPSHOT.war")
@@ -17,7 +17,7 @@ fn basic_war_app() {
                     "21",
                 ])
                 .current_dir(&context.app_dir),
-            "Running heroku-deploy-standalone failed.",
+            "Running heroku-jvm-application-deployer failed.",
             false,
         );
 
@@ -33,7 +33,7 @@ fn basic_jar_app() {
             Command::new("java")
                 .args([
                     "-jar",
-                    &heroku_deploy_standalone_path().to_string_lossy(),
+                    &heroku_jvm_application_deployer_jar_path().to_string_lossy(),
                     &context
                         .app_dir
                         .join("target/test-1.0-SNAPSHOT-jar-with-dependencies.jar")
@@ -42,7 +42,7 @@ fn basic_jar_app() {
                     "21",
                 ])
                 .current_dir(&context.app_dir),
-            "Running heroku-deploy-standalone failed.",
+            "Running heroku-jvm-application-deployer failed.",
             false,
         );
 

--- a/src/main/java/com/heroku/sdk/deploy/standalone/Main.java
+++ b/src/main/java/com/heroku/sdk/deploy/standalone/Main.java
@@ -20,7 +20,7 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
-@Command(name = "heroku-deploy-standalone", mixinStandardHelpOptions = true,
+@Command(name = "heroku-jvm-application-deployer", mixinStandardHelpOptions = true,
         description = "Application for deploying Java applications to Heroku.",
         defaultValueProvider = DefaultValueProvider.class)
 public class Main implements Callable<Integer> {
@@ -50,7 +50,7 @@ public class Main implements Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
-        System.out.println("Heroku Deploy (standalone)");
+        System.out.println("Heroku JVM Application Deployer");
         System.out.println();
 
         if (!appName.isPresent()) {
@@ -165,12 +165,12 @@ public class Main implements Callable<Integer> {
 
 
         String version = PropertiesUtils
-                .loadPomPropertiesOrEmptyFromClasspath(Main.class, "com.heroku.sdk", "heroku-deploy-standalone")
+                .loadPomPropertiesOrEmptyFromClasspath(Main.class, "com.heroku", "heroku-jvm-application-deployer")
                 .getProperty("version", "unknown");
 
         boolean deploySuccessful = Deployer.deploy(
                 apiKey.get(),
-                "heroku-deploy-standalone",
+                "heroku-jvm-application-deployer",
                 version,
                 deploymentDescriptor,
                 OUTPUT_ADAPTER);


### PR DESCRIPTION
Removes last mentions of `heroku-deploy-standalone` in non-code files.