### PR TITLE
CHANGELOG cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,123 +1,210 @@
 # Changelog
 
-## main
+All notable changes to this project will be documented in this file.
 
-### heroku-jvm-application-deployer
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
 
 * Add proper CLI to configure all aspects of app deployment. Previously used Java properties are no longer supported. See `--help` for usage. ([#232](https://github.com/heroku/heroku-maven-plugin/pull/232))
 * Unify usage between WAR and JAR files. heroku-jvm-application-deployer will now automatically use the correct mode based on file extension. ([#232](https://github.com/heroku/heroku-maven-plugin/pull/232))
 * Default `webapp-runner` version is now always the most recently released version. ([#232](https://github.com/heroku/heroku-maven-plugin/pull/232))
 
-## 3.0.5
+## [3.0.7] - 2023-02-06
+
+### Changed 
+
+* Update dependencies.
+
+## [3.0.6] - 2022-12-01
+
+### Changed
+
+* Update dependencies.
+
+## [3.0.5] - 2022-10-26
+
+### Changed
 
 * Update dependencies. ([#142](https://github.com/heroku/heroku-maven-plugin/pull/142))
 
-## 3.0.4
+## [3.0.4] - 2020-08-11
+
+### Fixed
 
 * Fix `heroku:deploy-war` goal. ([#77](https://github.com/heroku/heroku-maven-plugin/pull/77))
 
-## 3.0.3
+## [3.0.3] - 2020-07-09
+
+### Fixed
 
 * Add TLS workaround for OpenJDK 11.0.2. ([#72](https://github.com/heroku/heroku-maven-plugin/pull/72))
 
-## 3.0.2
+## [3.0.2] - 2020-03-30
+
+### Fixed
 
 * Fix Microsoft Windows support. ([#62](https://github.com/heroku/heroku-maven-plugin/pull/62))
 
-## 3.0.1
+## [3.0.1] - 2020-03-11
+
+### Fixed
 
 * Fix missing javadoc. ([#59](https://github.com/heroku/heroku-maven-plugin/pull/59))
 
-## 3.0.0
+## [3.0.0] - 2020-03-11
+
+### Changed
+
 * Extended documentation
 * Extensive refactoring, but mostly compatible with 2.x. See below for breaking changes.
-* BREAKING CHANGE: HTTP_PROXY and HTTPS_PROXY environment variables are no longer respected. Use [standard JVM proxy
-properties](https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html) to configure HTTP proxies.
-* BREAKING CHANGE: System property `heroku.curl.enabled` removed.
-* BREAKING CHANGE: Dropped support for Heroku Toolbelt on Windows. Use Heroku CLI instead.
-* BREAKING CHANGE: Support for `jvm-common` buildpack alias removed. Use standard `heroku/jvm` instead.
 
-## 2.0.16
+### Removed
+
+* HTTP_PROXY and HTTPS_PROXY environment variables are no longer respected. Use [standard JVM proxy
+properties](https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html) to configure HTTP proxies.
+* System property `heroku.curl.enabled` removed.
+* Dropped support for Heroku Toolbelt on Windows. Use Heroku CLI instead.
+* Support for `jvm-common` buildpack alias removed. Use standard `heroku/jvm` instead.
+
+## [2.0.16] - 2020-01-07
+
+### Changed
+
 * Upgrade to Tomcat Webapp Runner 9.0.30.0
 
-## 2.0.6
+## [2.0.6] - 2018-08-27
+
+### Changed
 
 * Upgrade to Tomcat Webapp Runner 8.5.33.0
 * Update default buildpack URL
 
-## 0.6.0
+## [0.5.0] - 2015-07-14
 
-* Added mechanism to set api key programmatically
-* Fix: Symlinks are imported into slug as files, not symlinks
-
-## 0.5.0
+### Changed
 
 * Upgraded to Tomcat 8 as default container
 
-## 0.4.4
+## [0.4.4] - 2015-07-01
+
+### Added
 
 * Added a warning for deploy-war when custom processTypes are present
 
-## 0.4.3
+## [0.4.3] - 2015-06-02
 
-* Accounted for Procfile's with empty lines in parsing
+### Added
+
 * Added ability to define custom buildpacks or multi-buildpack
 
-## 0.4.1
+### Fixed
+
+* Accounted for Procfile's with empty lines in parsing
+
+## [0.4.1] - 2015-05-12
+
+### Added
 
 * Added app name detection from Git repo.
 
-## 0.4.0 
+## [0.4.0] - 2015-05-11
+
+### Added
 
 * Added ability to log incremental progress of slug upload.
 
-## 0.3.6
+## [0.3.6] - 2015-04-03
+
+### Changed
 
 * Change config vars to overwrite existing values by default
 * Ignore POM packaging if `warFile` config is set
 
-## 0.3.5
+## [0.3.5] - 2015-03-05
+
+### Changed
 
 * Replaced javax.net with Apache HttpClient
 * Improved default JAVA_TOOL_OPTIONS
 
-## 0.3.4
+## [0.3.4] - 2015-02-10
 
-* Upgraded webapp-runner to 7.0.57.2
+### Added
+
 * Added `<includeTarget>` option to toggle the inclusion of the `target/` directory by default
 
-## 0.3.3
+### Changed
+
+* Upgraded webapp-runner to 7.0.57.2
+
+## [0.3.3] - 2015-02-09
+
+### Added
 
 *  Added commit string to slug meta-data
 
-## 0.3.2
+## [0.3.2] - 2015-01-29
+
+### Added
 
 *  Included with_jmap and with_jstack scripts.
-
 *  Added `heroku:create-slug` and `heroku:deploy-slug` goals
 
-## 0.3.1
+## [0.3.1] - 2015-01-15
 
-*  Added `heroku:run-war` goal to run a WAR file locally with a command similar on Heroku
+### Added
 
-*  Added `heroku:dashboard` goal to open the Heroku dashboard for the configured application
+* Added `heroku:run-war` goal to run a WAR file locally with a command similar on Heroku
+* Added `heroku:dashboard` goal to open the Heroku dashboard for the configured application
+* Added `heroku:eclipse-launch-config` goal to generate Eclipse launch configuration files
+* Added caching of the JDK so it won't be downloaded on every deploy 
 
-*  Began enforcement of `war` packaging when using `-war` goals
+### Changed
 
-*  Added `heroku:eclipse-launch-config` goal to generate Eclipse launch configuration files
+* Began enforcement of `war` packaging when using `-war` goals 
+* Switched from custom MojoExecutor to org.twdata.maven:mojo-executor
 
-*  Switched from custom MojoExecutor to org.twdata.maven:mojo-executor
+## [0.3.0] - 2014-12-18
 
-*  Added caching of the JDK so it won't be downloaded on every deploy
-
-## 0.3.0
+### Changed
 
 *  Jumping to 0.3.x version to align with sbt-heroku
+*  Use explicit versions in pom.xml
 
-*  [#4] Use explicit versions in pom.xml
+### Removed
 
-*  [#1] Remove support for Java 1.6
+*  Remove support for Java 1.6
 
-## 0.1.9
+## [0.1.9] - 2014-12-02
+
+### Changed
 
 *  Improved detection of Heroku API key. Now uses .netrc first.
+
+[unreleased]: https://github.com/heroku/heroku-maven-plugin/compare/v3.0.7...HEAD
+[3.0.7]: https://github.com/heroku/heroku-maven-plugin/compare/v3.0.6...v3.0.7
+[3.0.6]: https://github.com/heroku/heroku-maven-plugin/compare/v3.0.5...v3.0.6
+[3.0.5]: https://github.com/heroku/heroku-maven-plugin/compare/v3.0.4...v3.0.5
+[3.0.4]: https://github.com/heroku/heroku-maven-plugin/compare/v3.0.3...v3.0.4
+[3.0.3]: https://github.com/heroku/heroku-maven-plugin/compare/v3.0.2...v3.0.3
+[3.0.2]: https://github.com/heroku/heroku-maven-plugin/compare/v3.0.1...v3.0.2
+[3.0.1]: https://github.com/heroku/heroku-maven-plugin/compare/v3.0.0...v3.0.1
+[3.0.0]: https://github.com/heroku/heroku-maven-plugin/compare/v2.0.16...v3.0.0
+[2.0.16]: https://github.com/heroku/heroku-maven-plugin/compare/v2.0.6...v2.0.16
+[2.0.6]: https://github.com/heroku/heroku-maven-plugin/compare/v0.6.0...v2.0.6
+[0.5.0]: https://github.com/heroku/heroku-maven-plugin/compare/v0.4.4...v0.5.0
+[0.4.4]: https://github.com/heroku/heroku-maven-plugin/compare/v0.4.3...v0.4.4
+[0.4.3]: https://github.com/heroku/heroku-maven-plugin/compare/v0.4.2...v0.4.3
+[0.4.2]: https://github.com/heroku/heroku-maven-plugin/compare/v0.4.1...v0.4.2
+[0.4.1]: https://github.com/heroku/heroku-maven-plugin/compare/v0.4.0...v0.4.1
+[0.4.0]: https://github.com/heroku/heroku-maven-plugin/compare/v0.3.6...v0.4.0
+[0.3.6]: https://github.com/heroku/heroku-maven-plugin/compare/v0.3.5...v0.3.6
+[0.3.5]: https://github.com/heroku/heroku-maven-plugin/compare/v0.3.3...v0.3.5
+[0.3.4]: https://github.com/heroku/heroku-maven-plugin/compare/v0.3.2...v0.3.4
+[0.3.3]: https://github.com/heroku/heroku-maven-plugin/compare/v0.3.2...v0.3.3
+[0.3.2]: https://github.com/heroku/heroku-maven-plugin/compare/v0.3.1...v0.3.2
+[0.3.1]: https://github.com/heroku/heroku-maven-plugin/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/heroku/heroku-maven-plugin/compare/v0.1.9...v0.3.0
+[0.1.9]: https://github.com/heroku/heroku-maven-plugin/compare/v0.1.8...v0.1.9

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.heroku</groupId>
   <artifactId>heroku-jvm-application-deployer</artifactId>
-  <version>4.0.0-SNAPSHOT</version>
+  <version>4.0.0-RC1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Heroku JVM Application Deployer</name>


### PR DESCRIPTION
Cleans up the `CHANGELOG.md` file to conform to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). I also streamlined the tags in this repository so their naming scheme is consistent. Removed release `0.6.0` from the CHANGELOG because there is no tag for it for some reason.

The text in the unreleased section will get a separate PR since it's more extensive with the change from Maven Plugin to Heroku JVM Application Deployer.