### PR TITLE
Add release JAR to GH release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,7 @@ jobs:
           token: ${{ steps.generate-token.outputs.app_token }}
           tag_name: v${{ steps.new-version.outputs.version }}
           body: ${{ steps.changelog-entry.outputs.content }}
+          files: target/heroku-jvm-application-deployer-${{ steps.new-version.outputs.version }}.jar
 
       - name: Record next version
         id: next-version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-
-## [4.0.0-RC1] - 2023-11-21
-
+* Update release process to add the JAR file to GitHub releases. ([#240](https://github.com/heroku/heroku-maven-plugin/pull/240))
 * Add proper CLI to configure all aspects of app deployment. Previously used Java properties are no longer supported. See `--help` for usage. ([#232](https://github.com/heroku/heroku-maven-plugin/pull/232))
 * Unify usage between WAR and JAR files. heroku-jvm-application-deployer will now automatically use the correct mode based on file extension. ([#232](https://github.com/heroku/heroku-maven-plugin/pull/232))
 * Default `webapp-runner` version is now always the most recently released version. ([#232](https://github.com/heroku/heroku-maven-plugin/pull/232))

--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ It will automatically include and configure a Tomcat server via [webapp-runner](
 
 ## Installation
 
-Download the latest release from [Maven Central](https://repo1.maven.org/maven2/com/heroku/heroku-jvm-application-deployer/).
-The JAR file contains all required dependencies.
+Download the JAR file from the [latest release on GitHub](https://github.com/heroku/heroku-maven-plugin/releases/latest). Older releases can be downloaded from the [GitHub releases](https://github.com/heroku/heroku-maven-plugin/releases) list.
 
 ## Usage
 


### PR DESCRIPTION
It's much more ergonomic to download a file from the latest GitHub release than to use Maven Central file listings. This PR adds the main JAR file to the created GitHub release.