### PR TITLE
Improve error message when Heroku CLI is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* Improved the error message when the Heroku CLI is not installed or not available on `PATH`. ([#482](https://github.com/heroku/heroku-jvm-application-deployer/pull/482))
+* Updated dependencies
 
 ## [4.0.12] - 2025-11-03
 
+### Changed
+
+* Updated dependencies
 
 ## [4.0.11] - 2025-08-01
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,12 +53,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.21.3</version>
+      <version>2.19.2</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.21.3</version>
+      <version>2.19.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -68,18 +68,18 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.22.0</version>
+      <version>2.20.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
-      <version>1.15.0</version>
+      <version>1.14.0</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jgit</groupId>
       <artifactId>org.eclipse.jgit</artifactId>
       <!-- Starting with jgit 6.*, Java 11 is the minimum required version. Since we still support Java 8, we stick to jgit 5.*. -->
-      <version>5.13.5.202508271544-r</version>
+      <version>5.13.3.202401111512-r</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
@@ -89,7 +89,7 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.22.0</version>
+      <version>1.19.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -103,7 +103,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.15.0</version>
+        <version>3.14.0</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
@@ -112,7 +112,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.4.0</version>
+        <version>3.3.1</version>
         <executions>
           <execution>
             <id>attach-source</id>
@@ -125,7 +125,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.12.0</version>
+        <version>3.11.2</version>
         <executions>
           <execution>
             <id>attach-javadoc</id>
@@ -142,7 +142,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>3.7.1</version>
         <configuration>
           <descriptorRefs>
             <descriptorRef>jar-with-dependencies</descriptorRef>
@@ -186,7 +186,7 @@
       <plugin>
         <groupId>org.sonatype.central</groupId>
         <artifactId>central-publishing-maven-plugin</artifactId>
-        <version>0.10.0</version>
+        <version>0.8.0</version>
         <extensions>true</extensions>
         <configuration>
           <publishingServerId>central</publishingServerId>

--- a/pom.xml
+++ b/pom.xml
@@ -53,12 +53,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.19.2</version>
+      <version>2.21.3</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.19.1</version>
+      <version>2.21.3</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -68,18 +68,18 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.20.0</version>
+      <version>2.22.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
-      <version>1.14.0</version>
+      <version>1.15.0</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jgit</groupId>
       <artifactId>org.eclipse.jgit</artifactId>
       <!-- Starting with jgit 6.*, Java 11 is the minimum required version. Since we still support Java 8, we stick to jgit 5.*. -->
-      <version>5.13.3.202401111512-r</version>
+      <version>5.13.5.202508271544-r</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
@@ -89,7 +89,7 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.19.0</version>
+      <version>1.22.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -103,7 +103,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.14.0</version>
+        <version>3.15.0</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>
@@ -112,7 +112,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.3.1</version>
+        <version>3.4.0</version>
         <executions>
           <execution>
             <id>attach-source</id>
@@ -125,7 +125,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.11.2</version>
+        <version>3.12.0</version>
         <executions>
           <execution>
             <id>attach-javadoc</id>
@@ -142,7 +142,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>3.7.1</version>
+        <version>3.8.0</version>
         <configuration>
           <descriptorRefs>
             <descriptorRef>jar-with-dependencies</descriptorRef>
@@ -186,7 +186,7 @@
       <plugin>
         <groupId>org.sonatype.central</groupId>
         <artifactId>central-publishing-maven-plugin</artifactId>
-        <version>0.8.0</version>
+        <version>0.10.0</version>
         <extensions>true</extensions>
         <configuration>
           <publishingServerId>central</publishingServerId>

--- a/src/main/java/com/heroku/deployer/util/HerokuCli.java
+++ b/src/main/java/com/heroku/deployer/util/HerokuCli.java
@@ -46,7 +46,17 @@ public class HerokuCli {
 
         ProcessBuilder processBuilder = new ProcessBuilder(fullCommand);
         processBuilder.directory(workingDirectory.toFile());
-        Process process = processBuilder.start();
+
+        Process process;
+        try {
+            process = processBuilder.start();
+        } catch (IOException e) {
+            throw new IOException(
+                "Could not run the Heroku CLI. Please ensure the Heroku CLI is installed and available on PATH. " +
+                "Installation instructions: https://devcenter.heroku.com/articles/heroku-cli#install-the-heroku-cli",
+                e
+            );
+        }
 
         try (BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
             return bufferedReader.lines().collect(Collectors.toList());


### PR DESCRIPTION
When the `heroku` CLI is not installed or not on `PATH`, users previously saw a cryptic JVM message like `Cannot run program "heroku": CreateProcess error=2, The system cannot find the file specified`. The error is now wrapped with an actionable message pointing to the install instructions, while preserving the original exception as the cause.

Also does some CHANGELOG grooming.

GUS-W-22416546