### PR TITLE
Fix Windows compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,15 @@ permissions:
   contents: read
 
 jobs:
-  integration-linux:
-    name: "Integration Tests (Java ${{ matrix.java-version }})"
-    runs-on: ubuntu-24.04
+  integration:
+    name: "Integration Tests ${{ matrix.os }} (Java ${{ matrix.java-version }})"
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
         java-version:
           - 21
     env:
@@ -33,8 +36,18 @@ jobs:
           git config --global user.name "Example"
       - name: Update Rust toolchain
         run: rustup update
-      - name: Install Heroku CLI
+      - name: Install Heroku CLI (Linux)
+        if: runner.os == 'Linux'
         run: curl https://cli-assets.heroku.com/install.sh | sh
+      - name: Install Heroku CLI (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $tarballPath = "$env:RUNNER_TEMP\heroku-win32-x64.tar.gz"
+          Invoke-WebRequest -Uri "https://cli-assets.heroku.com/channels/stable/heroku-win32-x64.tar.gz" -OutFile $tarballPath
+          tar -xzf $tarballPath -C $env:RUNNER_TEMP
+          Add-Content -Path $env:GITHUB_PATH -Value "$env:RUNNER_TEMP\heroku\bin"
+          & "$env:RUNNER_TEMP\heroku\bin\heroku.cmd" --version
       - name: Package heroku-jvm-application-deployer
         run: "./mvnw --batch-mode package"
       - name: Package integration test fixtures

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* Heroku CLI invocation on Windows. ([#490](https://github.com/heroku/heroku-jvm-application-deployer/pull/490))
 
 ## [4.0.13] - 2026-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Heroku CLI invocation on Windows. ([#490](https://github.com/heroku/heroku-jvm-application-deployer/pull/490))
+* Use Unix path separators in the auto-generated Procfile when running on Windows. ([#490](https://github.com/heroku/heroku-jvm-application-deployer/pull/490))
+* Use Unix path separators for tar archive entry names when running on Windows. ([#490](https://github.com/heroku/heroku-jvm-application-deployer/pull/490))
 
 ## [4.0.13] - 2026-05-11
 

--- a/integration-test/src/lib.rs
+++ b/integration-test/src/lib.rs
@@ -73,7 +73,16 @@ pub fn create_heroku_app(path: &Path, space: Option<&str>) -> HerokuAppCreateRes
     }
 
     let output = run_command(
-        Command::new("heroku").args(args).current_dir(path),
+        // The Heroku CLI ships as `heroku.cmd` on Windows. `cmd.exe` resolves the bare
+        // name `heroku` via PATHEXT, but Rust's `Command` calls `CreateProcess` directly
+        // and skips that resolution, so we have to name the `.cmd` extension ourselves.
+        Command::new(if cfg!(windows) {
+            "heroku.cmd"
+        } else {
+            "heroku"
+        })
+        .args(args)
+        .current_dir(path),
         &format!("Could not create Heroku app in {}", path.display()),
         true,
     );
@@ -89,7 +98,15 @@ pub struct HerokuAppCreateResult {
 
 pub fn destroy_heroku_app(app_name: &str) {
     run_command(
-        Command::new("heroku").args(["destroy", app_name, "--confirm", app_name]),
+        // The Heroku CLI ships as `heroku.cmd` on Windows. `cmd.exe` resolves the bare
+        // name `heroku` via PATHEXT, but Rust's `Command` calls `CreateProcess` directly
+        // and skips that resolution, so we have to name the `.cmd` extension ourselves.
+        Command::new(if cfg!(windows) {
+            "heroku.cmd"
+        } else {
+            "heroku"
+        })
+        .args(["destroy", app_name, "--confirm", app_name]),
         &format!("Could not destroy Heroku app {app_name}"),
         true,
     );

--- a/integration-test/src/lib.rs
+++ b/integration-test/src/lib.rs
@@ -6,6 +6,15 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 use std::time::Duration;
 
+// The Heroku CLI ships as `heroku.cmd` on Windows. `cmd.exe` resolves the bare name
+// `heroku` via PATHEXT, but Rust's `Command` calls `CreateProcess` directly and skips
+// that resolution, so we have to name the `.cmd` extension ourselves.
+const HEROKU_PROGRAM: &str = if cfg!(windows) {
+    "heroku.cmd"
+} else {
+    "heroku"
+};
+
 pub fn prepare_test<F>(fixture_dir: &str, space: Option<&str>, f: F)
 where
     F: Fn(TestContext),
@@ -73,16 +82,7 @@ pub fn create_heroku_app(path: &Path, space: Option<&str>) -> HerokuAppCreateRes
     }
 
     let output = run_command(
-        // The Heroku CLI ships as `heroku.cmd` on Windows. `cmd.exe` resolves the bare
-        // name `heroku` via PATHEXT, but Rust's `Command` calls `CreateProcess` directly
-        // and skips that resolution, so we have to name the `.cmd` extension ourselves.
-        Command::new(if cfg!(windows) {
-            "heroku.cmd"
-        } else {
-            "heroku"
-        })
-        .args(args)
-        .current_dir(path),
+        Command::new(HEROKU_PROGRAM).args(args).current_dir(path),
         &format!("Could not create Heroku app in {}", path.display()),
         true,
     );
@@ -98,15 +98,7 @@ pub struct HerokuAppCreateResult {
 
 pub fn destroy_heroku_app(app_name: &str) {
     run_command(
-        // The Heroku CLI ships as `heroku.cmd` on Windows. `cmd.exe` resolves the bare
-        // name `heroku` via PATHEXT, but Rust's `Command` calls `CreateProcess` directly
-        // and skips that resolution, so we have to name the `.cmd` extension ourselves.
-        Command::new(if cfg!(windows) {
-            "heroku.cmd"
-        } else {
-            "heroku"
-        })
-        .args(["destroy", app_name, "--confirm", app_name]),
+        Command::new(HEROKU_PROGRAM).args(["destroy", app_name, "--confirm", app_name]),
         &format!("Could not destroy Heroku app {app_name}"),
         true,
     );

--- a/src/main/java/com/heroku/deployer/Main.java
+++ b/src/main/java/com/heroku/deployer/Main.java
@@ -221,7 +221,7 @@ public class Main implements Callable<Integer> {
             } else if (extension.equalsIgnoreCase("war")) {
                 return Optional.of(Procfile.singleton("web", String.format(
                         "java $JAVA_OPTS -jar %s $WEBAPP_RUNNER_OPTS --port $PORT %s",
-                        WEBAPP_RUNNER_SOURCE_BLOB_PATH,
+                        PathUtils.separatorsToUnix(WEBAPP_RUNNER_SOURCE_BLOB_PATH),
                         normalizedMainFile
                 )));
             }

--- a/src/main/java/com/heroku/deployer/sourceblob/SourceBlobPackager.java
+++ b/src/main/java/com/heroku/deployer/sourceblob/SourceBlobPackager.java
@@ -1,5 +1,6 @@
 package com.heroku.deployer.sourceblob;
 
+import com.heroku.deployer.util.PathUtils;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
@@ -31,7 +32,7 @@ public final class SourceBlobPackager {
                 System.out.println("       - including: " + sourceBlobPath);
             }
 
-            addIncludedPathToArchive(sourceBlobPath.toString(), content, tarArchiveOutputStream);
+            addIncludedPathToArchive(PathUtils.separatorsToUnix(sourceBlobPath), content, tarArchiveOutputStream);
         }
 
         tarArchiveOutputStream.close();

--- a/src/main/java/com/heroku/deployer/util/HerokuCli.java
+++ b/src/main/java/com/heroku/deployer/util/HerokuCli.java
@@ -10,6 +10,14 @@ import java.util.stream.Collectors;
 
 public class HerokuCli {
 
+    // The Heroku CLI ships as `heroku.cmd` on Windows. `cmd.exe` resolves the bare name
+    // `heroku` via PATHEXT, but Java's ProcessBuilder calls `CreateProcess` directly and
+    // skips that resolution, so we have to name the `.cmd` extension ourselves.
+    private static final String HEROKU_PROGRAM =
+        System.getProperty("os.name").toLowerCase(Locale.ROOT).startsWith("windows")
+            ? "heroku.cmd"
+            : "heroku";
+
     public static Optional<String> runAuthToken(Path workingDirectory) throws IOException {
         List<String> lines = runRaw(workingDirectory,"auth:token");
 
@@ -42,7 +50,7 @@ public class HerokuCli {
 
     private static List<String> runRaw(Path workingDirectory, String... command) throws IOException {
         List<String> fullCommand =  new ArrayList<>(Arrays.asList(command));
-        fullCommand.add(0, "heroku");
+        fullCommand.add(0, HEROKU_PROGRAM);
 
         ProcessBuilder processBuilder = new ProcessBuilder(fullCommand);
         processBuilder.directory(workingDirectory.toFile());


### PR DESCRIPTION
Fixes two issues that prevented running the deployer on Windows:

- Heroku CLI invocation: `ProcessBuilder` calls `CreateProcess` directly, which doesn't apply `PATHEXT` resolution, so the bare name `heroku` fails to locate `heroku.cmd`.
- Windows-style path separators in the deploy artifact: the auto-generated `Procfile` (used when the project doesn't ship its own) and tar archive entry names were built with `Path.toString()`, which produces backslashes on Windows. The Linux dyno then can't resolve those paths and the app crashes.

Also adds Windows to the integration test matrix to catch regressions.

GUS-W-23046781.
GUS-W-14479770.