### PR TITLE
Check API responses to surface deploy failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* Fail the deploy when the source blob upload returns a non-success HTTP status. Previously, a failed upload was reported as success and the build proceeded against a missing or stale source blob. ([#493](https://github.com/heroku/heroku-jvm-application-deployer/pull/493))
 
 ## [4.0.14] - 2026-06-17
 

--- a/src/main/java/com/heroku/deployer/deployment/Deployer.java
+++ b/src/main/java/com/heroku/deployer/deployment/Deployer.java
@@ -2,6 +2,7 @@ package com.heroku.deployer.deployment;
 
 import com.heroku.deployer.api.*;
 import com.heroku.deployer.util.io.UploadProgressHttpEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.FileEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -115,6 +116,11 @@ public final class Deployer {
         HttpPut request = new HttpPut(destination);
         request.setEntity(new UploadProgressHttpEntity(new FileEntity(path.toFile()), bytes -> progressConsumer.accept(bytes, fileSize)));
 
-        client.execute(request);
+        try (CloseableHttpResponse response = client.execute(request)) {
+            int statusCode = response.getStatusLine().getStatusCode();
+            if (statusCode != 200) {
+                throw new IOException(String.format("Unexpected status code uploading source blob: %d", statusCode));
+            }
+        }
     }
 }


### PR DESCRIPTION
The S3 PUT in `Deployer.uploadSourceBlob` was discarding the response and never inspecting the status code, so a failed upload (network blip, expired presigned URL, S3 permission error) was reported as success and the build proceeded against a missing or stale source blob.

GUS-W-23064262