### PR TITLE
Close HTTP and file resources via try-with-resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* Close `HttpClient` and response resources to prevent leaks during repeated invocations. ([#494](https://github.com/heroku/heroku-jvm-application-deployer/pull/494))
+* Validate the HTTP status when downloading webapp-runner so error responses no longer silently end up in the source blob. ([#494](https://github.com/heroku/heroku-jvm-application-deployer/pull/494))
+* Use try-with-resources in `SourceBlobPackager.pack` and clean up the temporary archive on failure. ([#494](https://github.com/heroku/heroku-jvm-application-deployer/pull/494))
 
 ## [4.0.14] - 2026-06-17
 

--- a/src/main/java/com/heroku/deployer/api/HerokuDeployApi.java
+++ b/src/main/java/com/heroku/deployer/api/HerokuDeployApi.java
@@ -43,27 +43,30 @@ public class HerokuDeployApi {
     }
 
     public SourceBlob createSourceBlob() throws IOException, HerokuDeployApiException {
-        CloseableHttpClient client = HttpClients.createSystem();
-
         HttpPost request = new HttpPost("https://api.heroku.com/sources");
         httpHeaders.forEach(request::setHeader);
 
-        CloseableHttpResponse response = client.execute(request);
+        try (CloseableHttpClient client = HttpClients.createSystem();
+             CloseableHttpResponse response = client.execute(request)) {
 
-        switch (response.getStatusLine().getStatusCode()) {
-            case HttpStatus.SC_ACCEPTED:
-            case HttpStatus.SC_CREATED:
-                HttpEntity responseEntity = response.getEntity();
-                String responseStringBody = Util.readLinesFromInputStream(responseEntity.getContent()).collect(Collectors.joining());
+            switch (response.getStatusLine().getStatusCode()) {
+                case HttpStatus.SC_ACCEPTED:
+                case HttpStatus.SC_CREATED:
+                    HttpEntity responseEntity = response.getEntity();
+                    String responseStringBody;
+                    try (Stream<String> lines = Util.readLinesFromInputStream(responseEntity.getContent())) {
+                        responseStringBody = lines.collect(Collectors.joining());
+                    }
 
-                JsonNode node = new ObjectMapper().readTree(responseStringBody);
-                String putUrl = node.get("source_blob").get("put_url").asText();
-                String getUrl = node.get("source_blob").get("get_url").asText();
+                    JsonNode node = new ObjectMapper().readTree(responseStringBody);
+                    String putUrl = node.get("source_blob").get("put_url").asText();
+                    String getUrl = node.get("source_blob").get("get_url").asText();
 
-                return new SourceBlob(putUrl, getUrl);
+                    return new SourceBlob(putUrl, getUrl);
 
-            default:
-                throw new HerokuDeployApiException(String.format("Unexpected status code: %d!", response.getStatusLine().getStatusCode()));
+                default:
+                    throw new HerokuDeployApiException(String.format("Unexpected status code: %d!", response.getStatusLine().getStatusCode()));
+            }
         }
     }
 
@@ -80,21 +83,20 @@ public class HerokuDeployApi {
         apiPayloadEntity.setContentType("application/json");
         apiPayloadEntity.setContentEncoding("UTF-8");
 
-        // Send request
-        CloseableHttpClient client = HttpClients.createSystem();
-
         HttpPatch request = new HttpPatch("https://api.heroku.com/apps/" + appName + "/config-vars");
         httpHeaders.forEach(request::setHeader);
         request.setEntity(apiPayloadEntity);
 
-        CloseableHttpResponse response = client.execute(request);
+        try (CloseableHttpClient client = HttpClients.createSystem();
+             CloseableHttpResponse response = client.execute(request)) {
 
-        switch (response.getStatusLine().getStatusCode()) {
-            case HttpStatus.SC_OK:
-                return;
+            switch (response.getStatusLine().getStatusCode()) {
+                case HttpStatus.SC_OK:
+                    return;
 
-            default:
-                throw new HerokuDeployApiException(String.format("Unexpected status code: %d!", response.getStatusLine().getStatusCode()));
+                default:
+                    throw new HerokuDeployApiException(String.format("Unexpected status code: %d!", response.getStatusLine().getStatusCode()));
+            }
         }
     }
 
@@ -122,30 +124,28 @@ public class HerokuDeployApi {
         apiPayloadEntity.setContentType("application/json");
         apiPayloadEntity.setContentEncoding("UTF-8");
 
-        // Send request
-        CloseableHttpClient client = HttpClients.createSystem();
-
         HttpPost request = new HttpPost("https://api.heroku.com/apps/" + appName + "/builds");
         request.setHeader("Heroku-Deploy-Type", "jvm-application-deployer");
 
         httpHeaders.forEach(request::setHeader);
         request.setEntity(apiPayloadEntity);
 
-        CloseableHttpResponse response = client.execute(request);
-
-        return handleBuildInfoResponse(appName, mapper, response);
+        try (CloseableHttpClient client = HttpClients.createSystem();
+             CloseableHttpResponse response = client.execute(request)) {
+            return handleBuildInfoResponse(appName, mapper, response);
+        }
     }
 
     public BuildInfo getBuildInfo(String appName, String buildId) throws IOException, HerokuDeployApiException {
         ObjectMapper mapper = new ObjectMapper();
-        CloseableHttpClient client = HttpClients.createSystem();
 
         HttpUriRequest request = new HttpGet("https://api.heroku.com/apps/" + appName + "/builds/" + buildId);
         httpHeaders.forEach(request::setHeader);
 
-        CloseableHttpResponse response = client.execute(request);
-
-        return handleBuildInfoResponse(appName, mapper, response);
+        try (CloseableHttpClient client = HttpClients.createSystem();
+             CloseableHttpResponse response = client.execute(request)) {
+            return handleBuildInfoResponse(appName, mapper, response);
+        }
     }
 
     public Stream<String> followBuildOutputStream(URI buildOutputStreamUri) throws IOException {
@@ -171,7 +171,10 @@ public class HerokuDeployApi {
             case HttpStatus.SC_OK:
             case HttpStatus.SC_CREATED:
                 HttpEntity responseEntity = response.getEntity();
-                String responseStringBody = Util.readLinesFromInputStream(responseEntity.getContent()).collect(Collectors.joining());
+                String responseStringBody;
+                try (Stream<String> lines = Util.readLinesFromInputStream(responseEntity.getContent())) {
+                    responseStringBody = lines.collect(Collectors.joining());
+                }
 
                 return mapper.readValue(responseStringBody, BuildInfo.class);
 

--- a/src/main/java/com/heroku/deployer/sourceblob/SourceBlobPackager.java
+++ b/src/main/java/com/heroku/deployer/sourceblob/SourceBlobPackager.java
@@ -17,25 +17,27 @@ public final class SourceBlobPackager {
     public static Path pack(SourceBlobDescriptor sourceBlobDescriptor) throws IOException {
         Path tarFilePath = Files.createTempFile("heroku-deploy", "source-blob.tgz");
 
-        TarArchiveOutputStream tarArchiveOutputStream = new TarArchiveOutputStream(
-                new GzipCompressorOutputStream(new FileOutputStream(tarFilePath.toFile())));
+        try (TarArchiveOutputStream tarArchiveOutputStream = new TarArchiveOutputStream(
+                new GzipCompressorOutputStream(new FileOutputStream(tarFilePath.toFile())))) {
 
-        tarArchiveOutputStream.setLongFileMode(TarArchiveOutputStream.LONGFILE_GNU);
+            tarArchiveOutputStream.setLongFileMode(TarArchiveOutputStream.LONGFILE_GNU);
 
-        System.out.println("-----> Packaging application...");
-        for (Path sourceBlobPath : sourceBlobDescriptor.getContents().keySet())  {
-            SourceBlobDescriptor.SourceBlobContent content = sourceBlobDescriptor.getContents().get(sourceBlobPath);
+            System.out.println("-----> Packaging application...");
+            for (Path sourceBlobPath : sourceBlobDescriptor.getContents().keySet())  {
+                SourceBlobDescriptor.SourceBlobContent content = sourceBlobDescriptor.getContents().get(sourceBlobPath);
 
-            if (content.isHidden()) {
-                System.out.println("       - including: " + sourceBlobPath + " (hidden)");
-            } else {
-                System.out.println("       - including: " + sourceBlobPath);
+                if (content.isHidden()) {
+                    System.out.println("       - including: " + sourceBlobPath + " (hidden)");
+                } else {
+                    System.out.println("       - including: " + sourceBlobPath);
+                }
+
+                addIncludedPathToArchive(PathUtils.separatorsToUnix(sourceBlobPath), content, tarArchiveOutputStream);
             }
-
-            addIncludedPathToArchive(PathUtils.separatorsToUnix(sourceBlobPath), content, tarArchiveOutputStream);
+        } catch (IOException e) {
+            Files.deleteIfExists(tarFilePath);
+            throw e;
         }
-
-        tarArchiveOutputStream.close();
 
         System.out.println("-----> Creating build...");
         System.out.println("       - file: " + tarFilePath);

--- a/src/main/java/com/heroku/deployer/util/FileDownloader.java
+++ b/src/main/java/com/heroku/deployer/util/FileDownloader.java
@@ -1,10 +1,14 @@
 package com.heroku.deployer.util;
 
-import java.io.FileOutputStream;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.URI;
-import java.nio.channels.Channels;
-import java.nio.channels.ReadableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -13,10 +17,25 @@ public class FileDownloader {
     public static Path download(URI uri) throws IOException {
         Path temporaryFilePath = Files.createTempFile("heroku-deploy-file-downloader", ".tmp");
 
-        FileOutputStream fileOutputStream = new FileOutputStream(temporaryFilePath.toFile());
-        ReadableByteChannel readableByteChannel = Channels.newChannel(uri.toURL().openStream());
+        HttpGet request = new HttpGet(uri);
 
-        fileOutputStream.getChannel().transferFrom(readableByteChannel, 0, Long.MAX_VALUE);
+        try (CloseableHttpClient client = HttpClients.createSystem();
+             CloseableHttpResponse response = client.execute(request)) {
+
+            int statusCode = response.getStatusLine().getStatusCode();
+            if (statusCode != 200) {
+                Files.deleteIfExists(temporaryFilePath);
+                throw new IOException(String.format("Unexpected status code downloading %s: %d", uri, statusCode));
+            }
+
+            HttpEntity entity = response.getEntity();
+            try (OutputStream out = Files.newOutputStream(temporaryFilePath)) {
+                entity.writeTo(out);
+            }
+        } catch (IOException e) {
+            Files.deleteIfExists(temporaryFilePath);
+            throw e;
+        }
 
         return temporaryFilePath;
     }


### PR DESCRIPTION
Several call sites leaked `Closeable` resources (HTTP client, response, output streams). Under repeated invocations the connection pool can stall, and on errors mid-stream the temporary tar archive leaked. `FileDownloader.download` also did not validate the HTTP status, so a 404 from Maven Central silently wrote an HTML error page into the source blob.

GUS-W-23064278