### PR TITLE
Poll build status until completion instead of fixed 30s cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* Wait for the build to complete instead of giving up after 30 seconds. Previously, successful long-running builds were reported as failed locally even though the build succeeded on Heroku. ([#496](https://github.com/heroku/heroku-jvm-application-deployer/pull/496))
 
 ## [4.0.14] - 2026-06-17
 

--- a/src/main/java/com/heroku/deployer/deployment/Deployer.java
+++ b/src/main/java/com/heroku/deployer/deployment/Deployer.java
@@ -80,7 +80,8 @@ public final class Deployer {
         try {
             buildInfo = pollForNonPendingBuildInfo(deploymentDescriptor.getAppName(), buildInfo.id, herokuDeployApi);
         } catch (HerokuDeployApiException e) {
-            System.out.println(String.format("Could not get updated build information. Will try again for some time... (%s)", e.getMessage()));
+            System.err.println("Could not get updated build information: " + e.getMessage());
+            return false;
         }
 
         if (!buildInfo.status.equals("succeeded")) {
@@ -95,17 +96,26 @@ public final class Deployer {
     }
 
     private static BuildInfo pollForNonPendingBuildInfo(String appName, String buildId, HerokuDeployApi herokuDeployApi) throws IOException, InterruptedException, HerokuDeployApiException {
-        for (int i = 0; i < 15; i++) {
+        long deadline = System.currentTimeMillis() + BUILD_POLL_TIMEOUT_MILLIS;
+
+        while (true) {
             BuildInfo latestBuildInfo = herokuDeployApi.getBuildInfo(appName, buildId);
             if (!latestBuildInfo.status.equals("pending")) {
                 return latestBuildInfo;
             }
 
-            Thread.sleep(2000);
-        }
+            if (System.currentTimeMillis() >= deadline) {
+                throw new HerokuDeployApiException(String.format(
+                        "Build did not complete within %d minutes.",
+                        BUILD_POLL_TIMEOUT_MILLIS / 60_000));
+            }
 
-        return herokuDeployApi.getBuildInfo(appName, buildId);
+            Thread.sleep(BUILD_POLL_INTERVAL_MILLIS);
+        }
     }
+
+    private static final long BUILD_POLL_TIMEOUT_MILLIS = 30 * 60 * 1000L;
+    private static final long BUILD_POLL_INTERVAL_MILLIS = 2000L;
 
     private static void uploadSourceBlob(Path path, URI destination, BiConsumer<Long, Long> progressConsumer) throws IOException {
         long fileSize = Files.size(path);


### PR DESCRIPTION
The deployer polled 15 times with a 2 second sleep, giving up after 30 seconds. That's enough for most builds since this tool is typically used to deploy already-built artifacts, but users can configure additional buildpacks whose build logic takes longer. Past the cap, the still-pending status tripped the success check and a successful build was reported as failed locally. Polls now continue until the build completes (`succeeded` or `failed`) with a 30 minute deadline, and hitting that deadline fails the deploy explicitly.

GUS-W-23064288